### PR TITLE
removed the "anonymous" thing

### DIFF
--- a/source/js/classes/crop-host.js
+++ b/source/js/classes/crop-host.js
@@ -218,9 +218,6 @@ crop.factory('cropHost', ['$document', 'cropAreaCircle', 'cropAreaSquare', 'crop
       events.trigger('image-updated');
       if(!!imageSource) {
         var newImage = new Image();
-        if(imageSource.substring(0,4).toLowerCase()==='http') {
-          newImage.crossOrigin = 'anonymous';
-        }
         newImage.onload = function(){
           events.trigger('load-done');
 


### PR DESCRIPTION
`newImage.crossOrigin = 'anonymous';` is used to prevent sending out info when in Cross Origin mode, but in Chrome, this causes even same origin requests to not send cookies (commonly used for auth with the backend).

For now, i'm removing.
